### PR TITLE
Make .app.src env entries type-sound / compatible with rebar3

### DIFF
--- a/src/alarms.app.src
+++ b/src/alarms.app.src
@@ -11,10 +11,10 @@
                  ]},
   {mod, {alarms_app, []}},
   {env, [
-         {handlers, [alarms_basic_handler, alarms_folsom_handler]},
-         {{alarms_basic_handler, min_log_interval}, 30},
-         {{alarms_basic_handler, report}, info_report},
-         {{alarms_folsom_handler, history_size}, 1000},
+         {handlers, [alarms_basic_handler]},
+         {'alarms_basic_handler.min_log_interval', 30},
+         {'alarms_basic_handler.report', info_report},
+         {'alarms_folsom_handler.history_size', 1000},
          {long_gc, 10000},
          {large_heap, 1000000}
         ]}

--- a/src/alarms_basic_handler.erl
+++ b/src/alarms_basic_handler.erl
@@ -194,7 +194,7 @@ handle_alarm(AlarmType, Details, Alarms0, LogTS0) ->
                     {ok, T} ->
                         calendar:datetime_to_gregorian_seconds(TS) -
                             calendar:datetime_to_gregorian_seconds(T) >=
-                            alarms_utils:get_cfg({?MODULE, min_log_interval});
+                            alarms_utils:get_cfg(?MODULE, min_log_interval);
                     error ->
                         true
                 end,
@@ -210,7 +210,7 @@ maybe_log(AlarmType, Count, Details) ->
            [mnesia_up, mnesia_down |
             ?SYSTEM_MONITOR_ALARM_TYPES ++ ?NET_KERNEL_ALARM_TYPES]) of
         true ->
-            Report = alarms_utils:get_cfg({?MODULE, report}),
+            Report = alarms_utils:get_cfg(?MODULE, report),
             error_logger:Report([{alarm, AlarmType},
                                  {count, Count},
                                  {details, Details}]),

--- a/src/alarms_folsom_handler.erl
+++ b/src/alarms_folsom_handler.erl
@@ -88,7 +88,7 @@ get_alarm(AlarmType, Limit) ->
 %%--------------------------------------------------------------------
 init(_) ->
     folsom:start(),
-    HistorySize = alarms_utils:get_cfg({?MODULE, history_size}),
+    HistorySize = alarms_utils:get_cfg(?MODULE, history_size),
     lists:foreach(
       fun(AlarmType) ->
               folsom_metrics:new_spiral({alarm, AlarmType, summary}),

--- a/src/alarms_utils.erl
+++ b/src/alarms_utils.erl
@@ -8,7 +8,7 @@
 %%%-------------------------------------------------------------------
 -module(alarms_utils).
 
--export([get_cfg/1, set_cfg/2, alarm_types/0, event_manager/0,
+-export([get_cfg/1, get_cfg/2, set_cfg/2, alarm_types/0, event_manager/0,
          now_epoch_usec/0, epoch_usec_to_local_time/1]).
 
 -include("alarms.hrl").
@@ -18,6 +18,12 @@
 get_cfg(Key) ->
     {ok, Val} = application:get_env(alarms, Key),
     Val.
+
+get_cfg(Mod, Key) ->
+    get_cfg(key(Mod, Key)).
+
+key(Mod, Key) ->
+    list_to_atom(atom_to_list(Mod) ++ "." ++ atom_to_list(Key)).
 
 set_cfg(Key, Val) ->
     application:set_env(alarms, Key, Val).


### PR DESCRIPTION
`man app` describes that env variable names should be atoms.